### PR TITLE
Update to SciJava Maven repository

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.scijava</groupId>
 		<artifactId>pom-scijava</artifactId>
-		<version>14.0.0</version>
+		<version>26.0.0</version>
 		<relativePath />
 	</parent>
 
@@ -86,8 +86,8 @@
 
 	<repositories>
 		<repository>
-			<id>imagej.public</id>
-			<url>https://maven.imagej.net/content/groups/public</url>
+			<id>scijava.public</id>
+			<url>https://maven.scijava.org/content/groups/public</url>
 		</repository>
 	</repositories>
 

--- a/pom.xml
+++ b/pom.xml
@@ -15,11 +15,11 @@
 
 	<name>ImageJ Ops Menu</name>
 	<description>ImageJ Ops Menu. A bridge between Ops, ImageJ and the good old Macro Recorder.</description>
-	<url>http://imagej.net/ImageJ_Ops</url>
+	<url>https://imagej.net/ImageJ_Ops</url>
 	<inceptionYear>2014</inceptionYear>
 	<organization>
 		<name>ImageJ</name>
-		<url>http://imagej.net/</url>
+		<url>https://imagej.net/</url>
 	</organization>
 	<licenses>
 		<license>

--- a/pom.xml
+++ b/pom.xml
@@ -52,8 +52,8 @@
 
 	<mailingLists>
 		<mailingList>
-			<name>ImageJ Forum</name>
-			<archive>http://forum.imagej.net/</archive>
+			<name>Image.sc Forum</name>
+			<archive>https://forum.image.sc/tags/imagej-ops-menu</archive>
 		</mailingList>
 	</mailingLists>
 


### PR DESCRIPTION
The maven.imagej.net repository became maven.scijava.org. This PR addresses that change, along with some other minor POM updates and improvements.